### PR TITLE
Allow blank filename lists so that ignore files are respected

### DIFF
--- a/autoload/greplace.vim
+++ b/autoload/greplace.vim
@@ -397,7 +397,7 @@ function! greplace#search(type, ...)
 
     if a:type == 'grep'
         if filenames == ''
-            let filenames = input('Search in files: ', '*', 'file')
+            let filenames = input('Search in files: ', '', 'file')
         endif
     elseif a:type == 'args'
         " Search in all the filenames in the argument list
@@ -424,7 +424,7 @@ function! greplace#search(type, ...)
         endfor
     endif
 
-    if filenames == ''
+    if a:type != 'grep' && filenames == ''
         call s:warn_msg('Error: No valid file names')
         return
     endif


### PR DESCRIPTION
Specifying '*' will cause any local ignore files to be skipped.

When all (non-ignored) files should be searched then no files should be specified for the grep program.

When not using a grep program, an error will still be raised if we end up with an empty list of files.

Tested to work with `ag` and `rg`.

References #6 